### PR TITLE
fix: remove duplicate entry for AMLOGIC_DDR_BANDWIDTH_S7

### DIFF
--- a/drivers/memory_debug/ddr_tool/Kconfig
+++ b/drivers/memory_debug/ddr_tool/Kconfig
@@ -160,16 +160,6 @@ config AMLOGIC_DDR_BANDWIDTH_S7
 		to get ddr total bandwidth, it can be used for
 		ddr DVFS/devfreq system.
 
-config AMLOGIC_DDR_BANDWIDTH_S7
-	bool "Meson ddr bandwidth for S7"
-	default n
-	depends on AMLOGIC_DDR_BANDWIDTH
-	help
-		This config enables ddr bandwidth measure for s7.
-		If open it, this driver will export interface
-		to get ddr total bandwidth, it can be used for
-		ddr DVFS/devfreq system.
-
 config AMLOGIC_DDR_BANDWIDTH_T6D
 	bool "Meson ddr bandwidth for T6D"
 	default n


### PR DESCRIPTION
Compiling [Current Linux kernel for Odroid C5](https://github.com/hardkernel/linux/tree/odroids7d-5.15.y) on NixOS fails with:
```
QUESTION:       Meson ddr bandwidth for S7, NAME: AMLOGIC_DDR_BANDWIDTH_S7, ALTS: Y/n/?, ANSWER:
GOT:
QUESTION:       Meson ddr bandwidth for S7, NAME: AMLOGIC_DDR_BANDWIDTH_S7, ALTS: Y/n/?, ANSWER:
repeated question:       Meson ddr bandwidth for S7
```